### PR TITLE
表示画面の配置・デザイン修正/一覧画面でギブアップ・正解済みがわかるように

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -111,11 +111,6 @@ h1 {
   gap: 0.25rem;
 }
 
-.tag-area {
-  padding: 0 0.5rem;
-  text-align: left;
-}
-
 /* 初正解時のアニメーション関係 */
 .modal-overlay {
   position: fixed;
@@ -188,7 +183,27 @@ h1 {
   margin: 1rem auto;
 }
 
+.give-up-alert {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
+  max-width: 600px;
+  padding: 1rem;
+  border-radius: 8px;
+  font-weight: bold;
+  text-align: center;
+  margin: 1em 0;
+  font-size: 1.1rem;
+  margin: 1rem auto;
+}
+
+
 /* タグ */
+.tag-area {
+  padding: 0 0.5rem;
+  text-align: left;
+}
+
 .tag-badge {
   display: inline-block;
   background-color: #e0f0ff;
@@ -203,11 +218,64 @@ h1 {
   white-space: nowrap;
 }
 
+.tag-badge:hover {
+  background-color: #cce5ff;
+  transform: scale(1.05);
+}
+
 .tagify__tag__removeBtn {
   color: white;
 }
 
+.popular-tags-title {
+  text-align: center;
+  margin-bottom: 1em;
+}
+
+.popular-tags-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5em;
+  margin-top: 1em;
+}
+
+.tag-badge-with-rank {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ランク表示 */
+.tag-rank {
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+/* 上位3位に色付け */
+.tag-badge-with-rank.gold .tag-rank {
+  background-color: #ffd700; /* gold */
+  color: #000;
+}
+
+.tag-badge-with-rank.silver .tag-rank {
+  background-color: #c0c0c0; /* silver */
+  color: #000;
+}
+
+.tag-badge-with-rank.bronze .tag-rank {
+  background-color: #cd7f32; /* bronze */
+  color: #fff;
+}
+
 /* 詳細画面用 */
+.quiz-show {
+  max-width: 600px;
+  margin: auto;
+}
+
 .quiz-detail-card {
   background-color: #fffef8;
   border: 2px solid #ffd43b;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -63,7 +63,7 @@ h1 {
 .quiz-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1rem;
+  gap: 1.5rem;
   padding: 0 1rem;
   justify-content: center; /* 追加: 中央寄せ */
   margin: 0 auto;           /* 追加: 中央寄せ */
@@ -109,6 +109,26 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+}
+
+.badge-success {
+  display: inline-block;
+  background-color: #d4edda;
+  color: #155724;
+  border-radius: 9999px;
+  padding: 0.3em 0.8em;
+  font-size: 0.8rem;
+  margin: 0em 2em;
+}
+
+.badge-warning {
+  display: inline-block;
+  background-color: #fff3cd;
+  color: #856404;
+  border-radius: 9999px;
+  padding: 0.3em 0.8em;
+  font-size: 0.8rem;
+  margin: 0em 2em;
 }
 
 /* 初正解時のアニメーション関係 */
@@ -418,7 +438,7 @@ h1 {
 }
 
 .search-form {
-  max-width: 500px;
+  max-width: 700px;
   padding: 0.6rem;
   font-size: 1rem;
   border-radius: 8px;
@@ -431,6 +451,7 @@ h1 {
   align-items: center;
   flex-wrap: wrap; /* スマホ対応 */
   margin-bottom: 1em;
+  padding: 0 1rem;
 }
 
 .pagination-container-under {
@@ -547,7 +568,7 @@ h1 {
   padding: 20px 10px;
   font-size: 14px;
   color: #333;
-  margin-top: 40px;
+  margin: 20px;
 }
 
 .footer-container {

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -22,8 +22,8 @@ class AnswersController < ApplicationController
     else
       @answer = Answer.new(question: @question, body: answer_params[:body], is_result: normalize(@question.correct) == normalize(answer_params[:body]))
       if @answer.is_result
-        session[:answered] ||= {}
-        session[:answered][@question.id] = true
+        session[:correct] ||= {}
+        session[:correct][@question.id] = true
         session[:first_correct] = true
       else
         #不正解のメッセージ

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -32,9 +32,10 @@ class QuestionsController < ApplicationController
       @answers = current_user.answers.where(question_id: params[:id])
       @already_correct = @answers.find { |a| a.is_result? }
     end
-    #初正解or不正解のフラグ（answer#createからredirect時に発生）
+    #初正解or不正解orギブアップのフラグ（answer#createからredirect時に発生）
     @first_correct = session.delete(:first_correct)
     @incorrect = session.delete(:incorrect)
+    @just_give_up = session.delete(:just_give_up)
   end
 
   def edit
@@ -59,7 +60,8 @@ class QuestionsController < ApplicationController
       session[:gave_up] ||= {}
       session[:gave_up][@question.id] = true
     end
-    redirect_to question_path(@question), notice: "ギブアップしました！答えを確認しましょう。"
+    session[:just_give_up] = true
+    redirect_to @question
   end
 
   def generate_hint

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -10,6 +10,14 @@ class QuestionsController < ApplicationController
       @questions = @q.result(distinct: true).includes(:user).order(created_at: :desc)
     end
     @questions = @questions.page(params[:page])
+
+    if user_signed_in?
+      @correct_question_ids = current_user.answers.where(is_result: true).pluck(:question_id).uniq
+      @gave_up_question_ids = current_user.give_ups.pluck(:question_id).uniq
+    else
+      @correct_question_ids = session[:correct]&.keys&.uniq&.map(&:to_i) || []
+      @gave_up_question_ids = session[:gave_up]&.keys&.uniq&.map(&:to_i) || []
+    end
   end
 
   def new

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -30,7 +30,20 @@
   <p>該当のクイズはありません！</p>
 <% end %>
 
-<h1>👑人気のタグ</h1>
-<% ActsAsTaggableOn::Tag.most_used(10).each do |tag| %>
-  <%= link_to tag.name, questions_path(tag_name: tag.name), class: "tag-badge" %>
-<% end %>
+<h1 class="popular-tags-title">👑人気のタグ TOP10</h1>
+
+<div class="popular-tags-wrapper">
+  <% ActsAsTaggableOn::Tag.most_used(10).each_with_index do |tag, index| %>
+    <% rank_class = case index
+      when 0 then "gold"
+      when 1 then "silver"
+      when 2 then "bronze"
+      else "normal"
+    end %>
+
+    <div class="tag-badge-with-rank <%= rank_class %>">
+      <span class="tag-rank"><%= index + 1 %>位</span>
+      <%= link_to tag.name, questions_path(tag_name: tag.name), class: "tag-badge" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -13,7 +13,14 @@
         <%= link_to question_path(question), class: "quiz-card-link" do %>
           <div class="quiz-card">
             <h2><%= question.content %></h2>
-            <p>作者：<%= question.user.name %></p>
+            <p>
+              <% if @correct_question_ids.include?(question.id) %>
+                <span class="badge badge-success">✅ 正解済み</span>
+              <% elsif @gave_up_question_ids.include?(question.id) %>
+                <span class="badge badge-warning">🏳️ ギブアップ</span>
+              <% end %>
+              作者：<%= question.user.name %>
+            </p>
           </div>
         <% end %>
         <div class="tag-area">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,106 +1,113 @@
 <h1>この絵文字から何を連想する？</h1>
-
-<div class="quiz-detail-card">
-  <h1><%= @question.content %></h1>
-  <%= render 'questions/tag', question: @question %>
-</div>
-
-<% if current_user == @question.user %>
-  <!-- 作問者画面　-->
-  <div class="form-group">
-    <p>答え：<%= @question.correct %></p>
-    <p>解答形式 ：<%= I18n.t("activerecord.attributes.question.answer_category.#{@question.answer_category}") %></p>
-    <p> ヒント1 ：<%= @question.hint_1 %></p>
-    <p> ヒント2 ：<%= @question.hint_2 %></p>
-    <p> ヒント3 ：<%= @question.hint_3 %></p>
-    <%= link_to "編集する ✏️", edit_question_path(@question), class: "btn-create" %>
-    <% toukou = "「#{@question.content}」絵文字クイズを作ったよ！これが解けるかな？🧩" %>
-    <% share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(request.original_url)}&text=#{CGI.escape(toukou)}&hashtags=EmojiLink" %>
-    <%= link_to "Xへ投稿する📢", share_url, class: "btn-share", target: "_blank", rel: "noopener" %><br>
+<div class="quiz-show">
+  <div class="quiz-detail-card">
+    <h1><%= @question.content %></h1>
+    <%= render 'questions/tag', question: @question %>
   </div>
-<% else %>
-    <% if @first_correct %>
-      <div id="first-correct-modal" class="modal-overlay">
-        <div class="modal-content">
-          🎉 正解おめでとう！🎉
-        </div>
-      </div>
-      <div id="emoji-confetti"></div>
-    <% end %>
-    <% if @incorrect %>
-      <div class="incorrect-alert">
-        😢 不正解でした！もう一度チャレンジしてみよう！
-      </div>
-    <% end %>
-  <!-- ログイン者用回答画面　-->
-  <% if current_user %>
-    <% if @already_correct&.is_result? %>
-      <!-- 既に正解　-->
-      <p>あなたの答え：<%= @already_correct.body %><br>
-        正   解  ：<%= @question.correct %><br>
-        結   果  ： <span class="correct">正　解　🎉</span> </p>
-      <p>ヒント1  ：<%= @question.hint_1 %><br>
-        ヒント2  ：<%= @question.hint_2 %><br>
-        ヒント3  ：<%= @question.hint_3 %></p>
-      <% toukou = "「#{@question.content}」に正解したよ！🎉皆は解けるかな？🧩" %>
+
+  <% if current_user == @question.user %>
+    <!-- 作問者画面　-->
+    <div class="form-group">
+      <p>答え：<%= @question.correct %></p>
+      <p>解答形式 ：<%= I18n.t("activerecord.attributes.question.answer_category.#{@question.answer_category}") %></p>
+      <p> ヒント1 ：<%= @question.hint_1 %></p>
+      <p> ヒント2 ：<%= @question.hint_2 %></p>
+      <p> ヒント3 ：<%= @question.hint_3 %></p>
+      <%= link_to "編集する ✏️", edit_question_path(@question), class: "btn-create" %>
+      <% toukou = "「#{@question.content}」絵文字クイズを作ったよ！これが解けるかな？🧩" %>
       <% share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(request.original_url)}&text=#{CGI.escape(toukou)}&hashtags=EmojiLink" %>
-      <%= link_to "Xへ投稿する📢", share_url, class: "btn-share", target: "_blank", rel: "noopener" %><br><br>
-    <% elsif current_user.given_up_questions.include?(@question) %>
-    <!-- ギブアップ済み -->
-        <%= render "questions/give_up", question: @question %>
-    <% else %>
-      <!-- ギブアップしていない場合は回答フォーム -->
-        <%= render "questions/answer_form", question: @question %>
-    <% end %>
+      <%= link_to "Xへ投稿する📢", share_url, class: "btn-share", target: "_blank", rel: "noopener" %><br>
+    </div>
   <% else %>
-  <!-- 非ログイン者用 -->
-    <% if session[:answered]&.dig(@question.id.to_s) %>
-      <!-- 既に正解　-->
-      <p>
-        正   解  ：<%= @question.correct %><br>
-        結   果  ： <span class="correct">正　解　🎉</span> </p>
-      <p>ヒント1  ：<%= @question.hint_1 %><br>
-        ヒント2  ：<%= @question.hint_2 %><br>
-        ヒント3  ：<%= @question.hint_3 %></p>
-      <% toukou = "「#{@question.content}」に正解したよ！🎉皆は解けるかな？🧩" %>
-      <% share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(request.original_url)}&text=#{CGI.escape(toukou)}&hashtags=EmojiLink" %>
-      <%= link_to "Xへ投稿する📢", share_url, class: "btn-share", target: "_blank", rel: "noopener" %><br><br>
-    <% elsif session[:gave_up]&.dig(@question.id.to_s) %>
+      <% if @first_correct %>
+        <div id="first-correct-modal" class="modal-overlay">
+          <div class="modal-content">
+            🎉 正解おめでとう！🎉
+          </div>
+        </div>
+        <div id="emoji-confetti"></div>
+      <% end %>
+      <% if @incorrect %>
+        <div class="incorrect-alert">
+          😢 不正解でした！もう一度チャレンジしてみよう！
+        </div>
+      <% end %>
+      <% if @just_give_up %>
+        <div class="give-up-alert">
+          🏳️ ギブアップしました！答えを確認しましょう。
+        </div>
+      <% end %>
+
+    <!-- ログイン者用回答画面　-->
+    <% if current_user %>
+      <% if @already_correct&.is_result? %>
+        <!-- 既に正解　-->
+        <p>あなたの答え：<%= @already_correct.body %><br>
+          正   解  ：<%= @question.correct %><br>
+          結   果  ： <span class="correct">正　解　🎉</span> </p>
+        <p>ヒント1  ：<%= @question.hint_1 %><br>
+          ヒント2  ：<%= @question.hint_2 %><br>
+          ヒント3  ：<%= @question.hint_3 %></p>
+        <% toukou = "「#{@question.content}」に正解したよ！🎉皆は解けるかな？🧩" %>
+        <% share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(request.original_url)}&text=#{CGI.escape(toukou)}&hashtags=EmojiLink" %>
+        <%= link_to "Xへ投稿する📢", share_url, class: "btn-share", target: "_blank", rel: "noopener" %><br><br>
+      <% elsif current_user.given_up_questions.include?(@question) %>
       <!-- ギブアップ済み -->
-        <%= render "questions/give_up", question: @question %>
+          <%= render "questions/give_up", question: @question %>
+      <% else %>
+        <!-- ギブアップしていない場合は回答フォーム -->
+          <%= render "questions/answer_form", question: @question %>
+      <% end %>
     <% else %>
-      <!-- 回答フォーム　-->
-      <%= render "questions/answer_form", question: @question %>
+    <!-- 非ログイン者用 -->
+      <% if session[:answered]&.dig(@question.id.to_s) %>
+        <!-- 既に正解　-->
+        <p>
+          正   解  ：<%= @question.correct %><br>
+          結   果  ： <span class="correct">正　解　🎉</span> </p>
+        <p>ヒント1  ：<%= @question.hint_1 %><br>
+          ヒント2  ：<%= @question.hint_2 %><br>
+          ヒント3  ：<%= @question.hint_3 %></p>
+        <% toukou = "「#{@question.content}」に正解したよ！🎉皆は解けるかな？🧩" %>
+        <% share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(request.original_url)}&text=#{CGI.escape(toukou)}&hashtags=EmojiLink" %>
+        <%= link_to "Xへ投稿する📢", share_url, class: "btn-share", target: "_blank", rel: "noopener" %><br><br>
+      <% elsif session[:gave_up]&.dig(@question.id.to_s) %>
+        <!-- ギブアップ済み -->
+          <%= render "questions/give_up", question: @question %>
+      <% else %>
+        <!-- 回答フォーム　-->
+        <%= render "questions/answer_form", question: @question %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
 
-  <!-- 履歴表示 -->
-<% if @answers&.any? %>
-  <table class="quiz-table">
-    <thead>
-      <tr>
-        <th>あなたの答え</th>
-        <th>結果</th>
-        <th>解答日時</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @answers.each do |answer| %>
+    <!-- 履歴表示 -->
+  <% if @answers&.any? %>
+    <table class="quiz-table">
+      <thead>
         <tr>
-          <td><%= answer.body %></td>
-          <td>
-            <% if answer.is_result %>
-              <span class="correct">⭕</span>
-            <% else %>
-              <span class="incorrect">❌</span>
-            <% end %>
-          </td>
-          <td><%= answer.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+          <th>あなたの答え</th>
+          <th>結果</th>
+          <th>解答日時</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table><br>
-<% end %>
+      </thead>
+      <tbody>
+        <% @answers.each do |answer| %>
+          <tr>
+            <td><%= answer.body %></td>
+            <td>
+              <% if answer.is_result %>
+                <span class="correct">⭕</span>
+              <% else %>
+                <span class="incorrect">❌</span>
+              <% end %>
+            </td>
+            <td><%= answer.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table><br>
+  <% end %>
 
-<%= link_to "← 他のクイズを見る", questions_path, class: "btn" %>
+  <%= link_to "← 他のクイズを見る", questions_path, class: "btn" %>
+</div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -60,7 +60,7 @@
       <% end %>
     <% else %>
     <!-- 非ログイン者用 -->
-      <% if session[:answered]&.dig(@question.id.to_s) %>
+      <% if session[:correct]&.dig(@question.id.to_s) %>
         <!-- 既に正解　-->
         <p>
           正   解  ：<%= @question.correct %><br>


### PR DESCRIPTION
#### 一覧画面
* ギブアップ/正解済みのクイズがわかるようにバッジを配置
* クイズカードの間隔調整
* 検索窓の位置
* 人気タグTOP10のデザイン変更

#### クイズ詳細画面
* クイズ詳細画面の情報を中央に統一