### PR TITLE
動線の整理

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -114,6 +114,164 @@ h1 {
   height: 18px;
 }
 
+/* --- ハンバーガーボタン --- */
+.hamburger-btn {
+  position: relative;
+  z-index: 1000; /* 他の要素より手前に表示 */
+  width: 42px;
+  height: 42px;
+  border: none;
+  background: #4caf50; /* ボタンの背景色 */
+  border-radius: 50%;
+  cursor: pointer;
+  display: none;
+}
+
+.hamburger-btn span {
+  display: block;
+  position: absolute;
+  left: 10px;
+  width: 22px;
+  height: 2px;
+  background-color: #fff; /* 線の色 */
+  transition: 0.3s;
+  border-radius: 2px;
+}
+
+.hamburger-btn span:nth-child(1) { top: 12px; }
+.hamburger-btn span:nth-child(2) { top: 20px; }
+.hamburger-btn span:nth-child(3) { bottom: 12px; }
+
+
+/* --- メニューが開いた時のボタン（×印）の形 --- */
+.hamburger-btn.is-active span:nth-child(1) {
+  top: 20px;
+  transform: rotate(45deg);
+}
+.hamburger-btn.is-active span:nth-child(2) {
+  opacity: 0;
+}
+.hamburger-btn.is-active span:nth-child(3) {
+  top: 20px;
+  transform: rotate(-45deg);
+}
+
+
+/* --- ナビゲーションメニュー本体 --- */
+.hamburger-nav {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 999;
+  width: 200px; /* メニューの幅 */
+  height: 100%;
+  background: #fff;
+  transform: translateX(100%); /* 初期状態は画面の外に隠す */
+  transition: 0.3s;
+  padding-top: 80px;
+}
+
+.hamburger-nav.is-active {
+  transform: translateX(0); /* 画面内に表示 */
+}
+
+.hamburger-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.hamburger-nav li a {
+  display: block;
+  padding: 15px 25px;
+  color: #333;
+  text-decoration: none;
+  font-size: 16px;
+}
+.hamburger-nav li a:hover {
+  background: #f5f5f5;
+}
+
+
+/* --- (オプション) 背景オーバーレイ --- */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 998;
+  opacity: 0;
+  visibility: hidden; /* クリックできないように */
+  transition: 0.3s;
+}
+
+.overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ログイン推奨画面 */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1001; /* ハンバーガーメニューより少し手前に */
+  display: none; /* 初期状態では非表示 */
+  justify-content: center;
+  align-items: center;
+}
+
+.modal.is-active {
+  display: flex; /* is-activeクラスが付いたら表示 */
+}
+
+.modal-content {
+  background: #fff;
+  padding: 25px 30px;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 90%;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.15);
+}
+
+.modal-content h4 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+}
+
+.modal-content p {
+  margin-bottom: 20px;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  border: none;
+  background: transparent;
+  font-size: 24px;
+  cursor: pointer;
+  color: #aaa;
+}
+.modal-close:hover {
+  color: #333;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+}
+
 /* クイズ一覧グリッド */
 .quiz-list {
   display: grid;
@@ -789,6 +947,11 @@ h3.section-title {
   color: #444;
 }
 
+.action-container {
+  display: flex;
+  justify-content: center;
+}
+
 .quiz-table {
   width: 100%;
   border-collapse: collapse;
@@ -959,6 +1122,10 @@ td.not-this-month {
 
   .header-nav {
     display: none;
+  }
+
+  .hamburger-btn {
+    display: block; /* ハンバーガーボタンを表示 */
   }
 
   .mobile-header {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -644,7 +644,7 @@ h1 {
   flex-wrap: nowrap;
 }
 
-.logout-mobile {
+.mobile-header {
   display: none;
 }
 
@@ -961,7 +961,7 @@ td.not-this-month {
     display: none;
   }
 
-  .logout-mobile {
+  .mobile-header {
     display: flex;
     align-items: center;
     justify-content: flex-end;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./tagify_setup"
+import "./hamburger"
 import { setupGenerateHint } from "./question_support";
 
 import emojiRegex from 'emoji-regex';
@@ -48,25 +49,40 @@ document.addEventListener("turbo:load", () => {
 
 //ツールチップ
 document.addEventListener("turbo:load", () => {
-  const toggleBtn = document.getElementById("toggle-emoji-tooltip");
-  const tooltip = document.getElementById("emoji-tooltip");
+  // 1. すべてのツールチップ切り替えボタンにイベントを設定
+  const toggleButtons = document.querySelectorAll("[data-tooltip-toggle]");
 
-  toggleBtn.addEventListener("click", () => {
-    if (tooltip.classList.contains("hidden")) {
-      tooltip.classList.remove("hidden");
-      tooltip.setAttribute("aria-hidden", "false");
-    } else {
-      tooltip.classList.add("hidden");
-      tooltip.setAttribute("aria-hidden", "true");
-    }
+  toggleButtons.forEach(button => {
+    button.addEventListener("click", (event) => {
+      // イベントが親要素へ伝わるのを防ぐ（重要）
+      event.stopPropagation();
+
+      const tooltipId = button.dataset.tooltipToggle;
+      const tooltip = document.getElementById(tooltipId);
+
+      if (!tooltip) return;
+
+      // 表示/非表示を切り替える
+      const isHidden = tooltip.classList.toggle("hidden");
+      tooltip.setAttribute("aria-hidden", String(isHidden));
+    });
   });
 
-  // 画面のどこかクリックで閉じる処理（任意）
-  document.addEventListener("click", (e) => {
-    if (!toggleBtn.contains(e.target) && !tooltip.contains(e.target)) {
+  // 2. ツールチップ本体がクリックされても閉じないようにする
+  const tooltips = document.querySelectorAll("[data-tooltip-body]");
+  tooltips.forEach(tooltip => {
+    tooltip.addEventListener("click", (event) => {
+      event.stopPropagation();
+    });
+  });
+
+
+  // 3. ドキュメントのどこかをクリックしたら、すべてのツールチップを閉じる
+  document.addEventListener("click", () => {
+    tooltips.forEach(tooltip => {
       tooltip.classList.add("hidden");
       tooltip.setAttribute("aria-hidden", "true");
-    }
+    });
   });
 });
 
@@ -111,3 +127,4 @@ document.addEventListener("turbo:load", () => {
     setTimeout(() => confetti.remove(), 4000);
   }
 });
+

--- a/app/javascript/hamburger.js
+++ b/app/javascript/hamburger.js
@@ -1,0 +1,65 @@
+document.addEventListener("turbo:load", () => {
+  // --- 要素をまとめて取得 ---
+  const overlay = document.getElementById("overlay");
+
+  // --- ログインモーダルの処理 ---
+  const openLoginBtn = document.getElementById("open-login-modal-btn");
+  const closeLoginBtn = document.getElementById("modal-close-btn");
+  const loginModal = document.getElementById("login-modal");
+
+  // ▼▼▼ ここからが修正箇所 ▼▼▼
+  if (openLoginBtn) { // 変数名を openLoginBtn に修正
+    openLoginBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      loginModal.classList.add("is-active"); // 変数名を loginModal に修正
+      overlay.classList.add("is-active");
+    });
+  }
+  // ▲▲▲ ここまでが修正箇所 ▲▲▲
+
+  if (closeLoginBtn) {
+    closeLoginBtn.addEventListener("click", () => {
+      loginModal.classList.remove("is-active");
+      overlay.classList.remove("is-active");
+    });
+  }
+
+  // --- ハンバーガーメニューの処理 ---
+  const hamburgerBtn = document.getElementById("hamburger-btn");
+  const hamburgerNav = document.getElementById("hamburger-nav");
+
+  if (hamburgerBtn) {
+    hamburgerBtn.addEventListener("click", () => {
+      hamburgerBtn.classList.toggle("is-active");
+      hamburgerNav.classList.toggle("is-active");
+      overlay.classList.toggle("is-active");
+    });
+  }
+
+  // --- オーバーレイのクリック処理（1つにまとめる） ---
+  if (overlay) {
+    overlay.addEventListener("click", () => {
+      // もしログインモーダルが開いていたら、それを閉じる
+      if (loginModal && loginModal.classList.contains("is-active")) {
+        loginModal.classList.remove("is-active");
+      }
+
+      // もしハンバーガーメニューが開いていたら、それを閉じる
+      if (hamburgerBtn && hamburgerBtn.classList.contains("is-active")) {
+        hamburgerBtn.classList.remove("is-active");
+        hamburgerNav.classList.remove("is-active");
+      }
+
+      // 最後にオーバーレイ自体を閉じる
+      overlay.classList.remove("is-active");
+    });
+  }
+});
+
+document.addEventListener("turbo:before-cache", () => {
+  // ページがキャッシュされる直前に、開いているモーダルやメニューをすべて閉じる
+  document.querySelector("#login-modal.is-active")?.classList.remove("is-active");
+  document.querySelector("#hamburger-nav.is-active")?.classList.remove("is-active");
+  document.querySelector("#hamburger-btn.is-active")?.classList.remove("is-active");
+  document.querySelector("#overlay.is-active")?.classList.remove("is-active");
+});

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -18,9 +18,9 @@
   <div class="form-group">
     <%= f.label :content, "クイズ" %> <span>：絵文字のみ/6個まで</span>
     <div style="position: relative; display: inline-block;">
-      <button id="toggle-emoji-tooltip" type="button" class="emoji-hint-toggle" title="絵文字入力ヒント" style="  font-size: 15px;">ℹ️</button>
+      <button type="button" class="emoji-hint-toggle" title="絵文字入力ヒント" style="font-size: 15px;" data-tooltip-toggle="hint-tooltip">ℹ️</button>
 
-      <div id="emoji-tooltip" class="emoji-tooltip hidden" role="tooltip" aria-hidden="true">
+      <div id="hint-tooltip" class="emoji-tooltip hidden" role="tooltip" aria-hidden="true" data-tooltip-body>
         絵文字ショートカットキー：<br>
         　「⌃」+「⌘」+「スペース」（Mac）<br>
         　「Windowsキー」+「.」（Windows）

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -12,11 +12,11 @@
     <% end %>
   <% else %>
 
+    <%= link_to new_question_path do %>
+      ✏️<br>クイズを作る
+    <% end %>
     <%= link_to new_user_session_path do %>
       🚪<br>ログイン
-    <% end %>
-    <%= link_to new_user_registration_path do %>
-      📝<br>ユーザー登録
     <% end %>
   <% end %>
 </nav>

--- a/app/views/shared/_bottom_nav.html.erb
+++ b/app/views/shared/_bottom_nav.html.erb
@@ -1,6 +1,6 @@
 <nav class="bottom-nav">
   <%= link_to root_path do %>
-    🏠<br>クイズ一覧
+    ❓<br>クイズ一覧
   <% end %>
 
   <% if user_signed_in? %>
@@ -11,12 +11,11 @@
       👤<br>マイページ
     <% end %>
   <% else %>
-
-    <%= link_to new_question_path do %>
-      ✏️<br>クイズを作る
-    <% end %>
     <%= link_to new_user_session_path do %>
       🚪<br>ログイン
+    <% end %>
+    <%= link_to new_user_registration_path do %>
+      📝<br>ユーザー登録
     <% end %>
   <% end %>
 </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,17 +8,28 @@
       <%= link_to 'マイページ', profile_path(current_user), class: "header-btn" %>
       <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_confirm: "ログアウトしてもよろしいですか？" }, class: "header-btn logout" %>
     <% else %>
+      <a class="btn-create">✏️ クイズを作る</a>
       <%= link_to 'ログイン', new_user_session_path, class: "header-btn" %>
       <%= link_to 'ユーザー登録', new_user_registration_path, class: "header-btn" %>
     <% end %>
   </nav>
 
-  <!-- モバイルでも常に表示するログアウトボタン -->
-  <% if user_signed_in? %>
-    <div class="logout-mobile">
+    <div style="position: relative; display: inline-block;">
+      <button id="make-quiz" type="button" class="btn-create" title="ログイン促進">✏️ クイズを作る</button>
+      <div id="emoji-tooltip" class="emoji-tooltip hidden" role="tooltip" aria-hidden="true">
+        <p>クイズを作成するにはログインが必要です。</p>
+        <div class="emoji-tooltip-arrow"></div>
+      </div>
+    </div>
+
+  <!-- モバイルで表示するログアウトボタン -->
+  <div class="mobile-header">
+    <% if user_signed_in? %>
       <%= link_to 'ログアウト', destroy_user_session_path, method: :delete,
                   data: { turbo_confirm: "ログアウトしてもよろしいですか？" },
                   class: "header-btn logout" %>
-    </div>
-  <% end %>
+    <% else %>
+      <%= link_to 'ユーザー登録', new_user_registration_path, class: "header-btn" %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,35 +1,66 @@
 <div class="site-header header-inner">
   <a href="/" class="header-logo">🧩Emoji Link</a>
 
-  <!-- ナビメニュー -->
+  <!-- PC用ナビメニュー -->
   <nav class="header-nav">
     <% if user_signed_in? %>
       <%= link_to '✏️ クイズを作る', new_question_path, class: 'btn-create' %>
       <%= link_to 'マイページ', profile_path(current_user), class: "header-btn" %>
       <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_confirm: "ログアウトしてもよろしいですか？" }, class: "header-btn logout" %>
     <% else %>
-      <a class="btn-create">✏️ クイズを作る</a>
+      <div style="position: relative; display: inline-block;">
+        <button type="button" class="btn-create" title="ログイン促進" data-tooltip-toggle="login-tooltip">✏️ クイズを作る</button>
+        <div id="login-tooltip" class="emoji-tooltip hidden" role="tooltip" aria-hidden="true" data-tooltip-body>
+          <p>クイズを作るにはログインが必要です。</p>
+          <div class="emoji-tooltip-arrow"></div>
+        </div>
+      </div>
       <%= link_to 'ログイン', new_user_session_path, class: "header-btn" %>
       <%= link_to 'ユーザー登録', new_user_registration_path, class: "header-btn" %>
     <% end %>
   </nav>
 
-    <div style="position: relative; display: inline-block;">
-      <button id="make-quiz" type="button" class="btn-create" title="ログイン促進">✏️ クイズを作る</button>
-      <div id="emoji-tooltip" class="emoji-tooltip hidden" role="tooltip" aria-hidden="true">
-        <p>クイズを作成するにはログインが必要です。</p>
-        <div class="emoji-tooltip-arrow"></div>
-      </div>
-    </div>
 
-  <!-- モバイルで表示するログアウトボタン -->
-  <div class="mobile-header">
-    <% if user_signed_in? %>
-      <%= link_to 'ログアウト', destroy_user_session_path, method: :delete,
-                  data: { turbo_confirm: "ログアウトしてもよろしいですか？" },
-                  class: "header-btn logout" %>
-    <% else %>
-      <%= link_to 'ユーザー登録', new_user_registration_path, class: "header-btn" %>
-    <% end %>
+  <!-- モバイル用ナビメニュー -->
+  <button id="hamburger-btn" class="hamburger-btn" aria-label="メニューを開く" aria-controls="hamburger-nav" aria-expanded="false">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
+
+  <nav id="hamburger-nav" class="hamburger-nav" aria-hidden="true">
+    <ul>
+      <li><%= link_to '❓クイズ一覧', questions_path %></li>
+      <% if user_signed_in? %>
+        <li><%= link_to '✏️クイズを作る', new_question_path %></li>
+        <li><%= link_to '👤マイページ', profile_path(current_user) %></li>
+        <hr>
+        <li>
+          <%= link_to '🎈ログアウト', destroy_user_session_path, method: :delete, data: { turbo_confirm: "ログアウトしてもよろしいですか？" } %>
+        </li>
+      <% else %>
+        <li><%= link_to '🚪ログイン', new_user_session_path %></li>
+        <li><%= link_to '📝ユーザー登録', new_user_registration_path %></li>
+        <hr>
+        <li>
+          <a href="#" id="open-login-modal-btn" title="クイズを作るにはログインが必要です">✏️クイズを作る</a>
+        </li>
+      <% end %>
+      <li><%= link_to '📘遊び方(作成中)'  %></li>
+    </ul>
+  </nav>
+
+  <div id="overlay" class="overlay"></div>
+</div>
+
+<div id="login-modal" class="modal">
+  <div class="modal-content">
+    <button id="modal-close-btn" class="modal-close" aria-label="閉じる">×</button>
+    <h4>ログインが必要です</h4>
+    <p>クイズを作成したり、他のクイズを評価するにはログインが必要です。</p>
+    <div class="modal-actions">
+      <a href="/users/sign_up" class="btn-create">新規登録</a>
+      <a href="/users/sign_in" class="header-btn">ログイン</a>
+    </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
   </h1>
   <section>
     <h3 class="section-title">マイページアクション</h3>
-    <div class="container">
+    <div class="action-container">
       <%= link_to "プロフィールを編集", edit_profile_path(@user), class: "edit-profile-btn" %>
       <%= link_to "ログインカレンダー", calendar_path, class: "calendar-btn" %>
     </div>


### PR DESCRIPTION
### 目的
新規ユーザーの登録をしやすくなるよう動線を整理

### 方法
スマホ画面でハンバーガーメニューを追加。
ハンバーガーメニューに機能の一覧を載せ、登録が必要な機能を使おうとした際にユーザー登録を促すよう修正。
頻繁に使う機能はボトムナビに抽出（大きな変更なし）

■住み分け
・ハンバーガーメニュー　→　機能の一覧を表示（サイトマップ的な使い方）
・ボトムナビ　→　頻繁に使う機能を常に表示（ショートカット的な使い方）