### PR TITLE
header位置の固定

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -61,7 +61,7 @@ h1 {
 .wrapper {
   display: flex;
   flex-direction: column;
-  padding: 2rem;
+  padding: 1rem 2rem;
   min-height: 100vh;
 }
 
@@ -771,7 +771,7 @@ h1 {
   padding: 1rem 1.5rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   position: sticky;
-  top: 0;
+  top: 1rem;
   z-index: 100;
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,8 +36,8 @@
 
   <body>
     <div class="wrapper">
-      <%= render 'shared/message' %>
       <%= render 'shared/header' %>
+      <%= render 'shared/message' %>
       <div class="main-contents">
         <%= yield %><br>
       </div>


### PR DESCRIPTION
下側にスクロールするとheaderの上側にある隙間が消えてしまい、
ハンバーガーボタンが少し動いてしまうためheader上部の隙間が消えないように修正