### PR TITLE
タグ検索後の対象タグを明示/ユーザー名→ログイン中へ変更

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -54,7 +54,7 @@ body {
 h1 {
   text-align: center;
   font-size: 2rem;
-  margin-bottom: 2rem;
+  margin: 1rem 0;
   color: #444;
 }
 
@@ -729,6 +729,26 @@ h1 {
   padding: 0 1rem;
 }
 
+.search-info {
+  font-size: 0.9rem;
+  color: #666;
+  margin: 0.5rem 0;
+  text-align: center;
+}
+
+.clear-search-link {
+  font-size: 0.9rem;
+  color: #007bff;
+  text-decoration: none;
+  font-weight: bold;
+  padding: 4px 8px;
+  border-radius: 6px;
+  margin-left: 1rem;
+}
+
+.clear-search-link:hover {
+  background-color: #f0f0f0;
+}
 /* ツールチップ */
 .emoji-hint-toggle {
   border: none;
@@ -819,11 +839,9 @@ h1 {
   align-items: center;
 }
 
-.user-name {
+.login-mode {
   margin-right: 1rem;
-}
-.user-name a {
-  color: #333;
+  color: #474747;
   text-decoration: none;
   font-weight: bold;
 }
@@ -1281,7 +1299,7 @@ td.not-this-month {
   h1 {
     text-align: center;
     font-size: 1.6rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
     color: #444;
   }
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -12,6 +12,7 @@ class QuestionsController < ApplicationController
                             .includes(:user)
                             .order(created_at: :desc)
                             .page(params[:page])
+      @searched_tag = params[:tag_name]
     else
       @questions = @q.result(distinct: true)
                       .includes(:user)

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -15,6 +15,13 @@
       </div>
     </div>
 
+    <% if @searched_tag %>
+      <div class="search-info">
+        <span class="tag-badge"> <%= @searched_tag %> </span>で検索中
+        <%= link_to "検索クリア", questions_path, class: "clear-search-link" %>
+      </div>
+    <% end %>
+
     <div class="quiz-list">
       <% @questions.each do |question| %>
         <div class="quiz-card-wrapper">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <a href="/" class="header-logo">🧩Emoji Link</a>
 
   <div class="header-right">
-    <span class="user-name">ようこそ！<%= user_signed_in? ? current_user.name : "ゲスト" %>さん</span>
+    <span class="login-mode"><%= user_signed_in? ? "ログイン中" : "ゲストモード" %></span>
 
     <button id="hamburger-btn" class="hamburger-btn" aria-label="メニューを開く" aria-controls="hamburger-nav" aria-expanded="false">
       <span></span>


### PR DESCRIPTION
### UIの修正
* スマホ画面が崩れていたので修正
ログイン時　：「ようこそ！ユーザー名さん」　→　「ログイン中」
非ログイン時：「ようこそ！ゲストさん」　→　「ゲストモード」

* タグでクイズを抽出した際に、何のタグで抽出しているかわかるように表示追加