### PR TITLE
クイズの二重送信防止/ログイン状態UI修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -643,6 +643,12 @@ h1 {
 .btn-create:hover {
   background-color: #2f9e44;
 }
+.btn-create:disabled {
+  background-color: #65686b; /* グレー */
+  color: #f1f3f5;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
 
 .btn-login {
   background-color: #40c057;
@@ -844,6 +850,22 @@ h1 {
   color: #474747;
   text-decoration: none;
   font-weight: bold;
+}
+
+.status-badge {
+  font-size: 1rem;
+  font-weight: bold;
+  padding: 4px 10px;
+  border-radius: 12px;
+  color: #fff;
+}
+
+.status-badge.logged-in {
+  background-color: #ffb13c;
+}
+
+.status-badge.logged-out {
+  background-color: #5b58ff;
 }
 
 .terms-container {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -47,6 +47,21 @@ document.addEventListener("turbo:load", () => {
   });
 });
 
+//二重登録防止
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.querySelector("form");
+  const submitBtn = document.getElementById("submit-btn");
+
+  if (!form || !submitBtn) return;
+
+  form.addEventListener("submit", () => {
+    submitBtn.disabled = true;
+    submitBtn.value = '送信中...';
+    submitBtn.classList.add("btn-disabled");
+  });
+});
+
+
 //ツールチップ
 document.addEventListener("turbo:load", () => {
   // 1. すべてのツールチップ切り替えボタンにイベントを設定

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,4 +1,3 @@
-<div class="quiz-show">
   <%= form_with(model: question, local: true, data: { turbo: false }) do |f| %>
     <% if question&.errors&.any? %>
       <div class="alert alert-danger">
@@ -52,6 +51,5 @@
       <%= f.text_field :hint_3, id: "hint_3_input", class: "form-control", placeholder: "例: 「計画通り」/「新世界の神になる」" %>
     </div>
 
-    <%= f.submit question.new_record? ? "クイズを作成する🚀" : "保存する💾", class: "btn-create" %><br><br>
+    <%= f.submit question.new_record? ? "クイズを作成する🚀" : "保存する💾", id: "submit-btn", class: "btn-create" %><br><br>
   <% end %>
-</div>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>問題を編集する ✏️</h1>
-
-<%= render "form", question: @question %>
-
-<%= link_to "戻る", question_path(@question), class: "btn mt-3" %>
+<div class="quiz-show">
+  <%= render "form", question: @question %>
+  <%= link_to "戻る", question_path(@question), class: "btn mt-3" %>
+</div>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,3 +1,4 @@
 <h1>✏️ 絵文字クイズを作る</h1>
-
-<%= render "form", question: @question %>
+<div class="quiz-show">
+  <%= render "form", question: @question %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,13 @@
   <a href="/" class="header-logo">🧩Emoji Link</a>
 
   <div class="header-right">
-    <span class="login-mode"><%= user_signed_in? ? "ログイン中" : "ゲストモード" %></span>
+    <div class="login-mode">
+      <% if user_signed_in? %>
+        <span class="status-badge logged-in">ログイン中✅</span>
+      <% else %>
+        <span class="status-badge logged-out">ゲストモード🔰</span>
+      <% end %>
+    </div>
 
     <button id="hamburger-btn" class="hamburger-btn" aria-label="メニューを開く" aria-controls="hamburger-nav" aria-expanded="false">
       <span></span>


### PR DESCRIPTION
### UI/UX修正
* UX:クイズ作成画面で「クイズを作る」ボタンを複数回押すとクイズも複数個作られてしまうため
　　JS制御により「クイズを作る」ボタンを一度押すと押せなくなるように修正

* UI:ヘッダーのログイン状態をバッジ風に修正
* UI:編集画面の「戻る」ボタンが親コンポーネントから漏れていたのを修正