### PR TITLE
次or前のクイズへボタン実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -68,7 +68,7 @@ body {
 h1 {
   text-align: center;
   font-size: 2rem;
-  margin: 1rem 0;
+  margin: 5px 0;
   color: #444;
 }
 
@@ -548,6 +548,18 @@ h1 {
   margin: auto;
 }
 
+.navigation-buttons {
+  display: flex;
+  margin: 10px 0;
+}
+
+.navigation-buttons .right {
+  margin-left: auto;
+}
+.navigation-buttons .left {
+  margin-right: auto;
+}
+
 .quiz-detail-card {
   background-color: #fffef8;
   border: 2px solid #ffd43b;
@@ -555,7 +567,7 @@ h1 {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
   padding: 2rem;
   max-width: 600px;
-  margin: 2rem auto 0;
+  margin: 1rem auto 0;
   text-align: left;
   font-family: "Helvetica Neue", sans-serif;
 }
@@ -1340,7 +1352,6 @@ td.not-this-month {
   h1 {
     text-align: center;
     font-size: 1.6rem;
-    margin-bottom: 1rem;
     color: #444;
   }
 

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -53,7 +53,7 @@
     </div>
 
     <%= f.submit question.new_record? ? "クイズを作成する🚀" : "保存する💾", id: "submit-btn", class: "btn-create" %><br><br>
-    <%= link_to "戻る", (request.referer || questions_path), class: "btn mt-3" %>
+    <%= link_to "戻る", (request.referer || questions_path), class: "btn" %>
 
   <% end %>
 </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,5 +1,14 @@
-<h1>この絵文字から何を連想する？</h1>
 <div class="quiz-show">
+  <div class="navigation-buttons">
+    <% if @prev_id %>
+      <%= link_to "←前のクイズ", question_path(@prev_id), class: "btn left" %>
+    <% end %>
+    <% if @next_id %>
+      <%= link_to "次のクイズ→", question_path(@next_id), class: "btn right" %>
+    <% end %>
+  </div>
+
+  <h1>この絵文字から何を連想する？</h1>
   <div class="quiz-detail-card">
     <h1><%= @question.content %></h1>
     <%= render 'questions/tag', question: @question %>
@@ -131,5 +140,6 @@
     </table><br>
   <% end %>
 
-  <%= link_to "← 他のクイズを見る", questions_path, class: "btn" %>
+
+  <%= link_to "戻る", (request.referer || questions_path), class: "btn" %>
 </div>


### PR DESCRIPTION
### クイズ詳細画面で次or前のクイズへ移動できるボタンを実装
* 一覧画面（検索後含む）のクイズカードの順番をセッションに保存し、詳細画面で前後のidを参照したリンクを作成
* その他修正
「他のクイズを見る」を「戻るボタン」に修正
`question_controller`内の`before_action`対象のメソッドを見直し