### PR TITLE
ページネーションで次のクイズが途切れる問題を解消

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -20,7 +20,7 @@ class QuestionsController < ApplicationController
 
     # 検索条件があるときだけ記憶/ない場合は削除
     if params[:q].present? || params[:tag_name].present?
-      session[:last_search] = scope.pluck(:id, :created_at).map(&:first)
+      session[:last_search] = scope.query_parameters
     else
       session.delete(:last_search)
     end


### PR DESCRIPTION
`1ページ目の最後に表示されるクイズ`から`２ページ目の最初に表示されるクイズ`に移動するためのボタンが表示されない問題を解消
原因：ページネーションメソッド`page(params[:page])`後にクイズの並び順を取得していたため。
修正：ページネーションメソッドを`index`の最後に着けるよう修正。