### PR TITLE
デプロイエラー修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,8 @@
 /tmp
 tmp/*
 tmp/**/*
+# tmp 配下の隠しファイル対策（Chrome等）
+tmp/.*
 
 !/log/.keep
 !/tmp/.keep

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -20,7 +20,7 @@ class QuestionsController < ApplicationController
 
     # 検索条件があるときだけ記憶/ない場合は削除
     if params[:q].present? || params[:tag_name].present?
-      session[:last_search] =  { q: params[:q], tag_name: params[:tag_name] }
+      session[:last_search] = { q: params[:q], tag_name: params[:tag_name] }
     else
       session.delete(:last_search)
     end


### PR DESCRIPTION
tmpファイルに存在するChromeが作成した隠しファイル(.ファイル名)を権限がなく読み込もうとしてデプロイエラーが出ていた。

今後同様のエラーが出ないように以下の対策を行った。
* gitignoreにtmpファイルの隠しファイルを読み込まないように設定。